### PR TITLE
chore(deps): bump postcss override to ^8.5.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13887,9 +13887,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -23610,7 +23610,7 @@
       "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.10",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
@@ -23626,7 +23626,7 @@
       "requires": {
         "cssnano": "^5.0.6",
         "jest-worker": "^27.0.2",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.10",
         "schema-utils": "^4.0.0",
         "serialize-javascript": "^7.0.5",
         "source-map": "^0.6.1"
@@ -28390,9 +28390,9 @@
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
     "postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -29330,7 +29330,7 @@
         "jest-resolve": "^27.4.2",
         "jest-watch-typeahead": "^1.0.0",
         "mini-css-extract-plugin": "^2.4.5",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.10",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^6.2.1",
         "postcss-normalize": "^10.0.1",
@@ -29556,7 +29556,7 @@
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.10",
         "source-map": "0.6.1"
       },
       "dependencies": {
@@ -30420,7 +30420,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.10",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serialize-javascript": "^7.0.5",
     "svgo": "^3.3.2",
     "flatted": "^3.3.1",
-    "postcss": "^8.4.31",
+    "postcss": "^8.5.10",
     "@tootallnate/once": "^3.0.1",
     "webpack-dev-server": "^5.2.1",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",


### PR DESCRIPTION
Closes Dependabot alert #89 (medium: XSS via unescaped `</style>` in CSS stringify output). postcss resolves to 8.5.14, build clean, `npm audit` reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)